### PR TITLE
ensure /etc/resolver exists

### DIFF
--- a/pharod-start
+++ b/pharod-start
@@ -12,6 +12,8 @@ if pgrep -qx pharod; then
   exit 1
 fi
 
+sudo mkdir -p /etc/resolver
+
 if pgrep -qx com.docker.backend; then
   echo "** Detected Docker for Mac"
 


### PR DESCRIPTION
May be an edge case, but this directory didn't exist for me on OS X 10.11.6?
`-p` flag for mkdir will ensure dir is only created if it doesn't already exist.